### PR TITLE
bugfix/ Variables invalidation due to FERNET_KEY

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -119,6 +119,10 @@ resource "aws_ecs_task_definition" "airflow" {
         "environment": [
           ${join(",\n", formatlist("{\"name\":\"%s\",\"value\":\"%s\"}", keys(local.airflow_variables), values(local.airflow_variables)))}
         ],
+        "secrets": [{
+          "name": "AIRFLOW__CORE__FERNET_KEY",
+          "valueFrom": "arn:aws:ssm:${var.region}:${data.aws_caller_identity.this.account_id}:parameter/${var.resource_suffix}/airflow/fernet_key"
+        }],
         "logConfiguration": {
           "logDriver": "awslogs",
           "options": {
@@ -160,6 +164,10 @@ resource "aws_ecs_task_definition" "airflow" {
         ],
         "secrets": [{
           "name": "FERNET_KEY",
+          "valueFrom": "arn:aws:ssm:${var.region}:${data.aws_caller_identity.this.account_id}:parameter/${var.resource_suffix}/airflow/fernet_key"
+        },
+        {
+          "name": "AIRFLOW__CORE__FERNET_KEY",
           "valueFrom": "arn:aws:ssm:${var.region}:${data.aws_caller_identity.this.account_id}:parameter/${var.resource_suffix}/airflow/fernet_key"
         }],
         "logConfiguration": {

--- a/locals.tf
+++ b/locals.tf
@@ -37,6 +37,7 @@ locals {
     AIRFLOW__WEBSERVER__RBAC : var.airflow_authentication == "" ? false : true,
     AIRFLOW__WEBSERVER__AUTH_BACKEND : lookup(local.auth_map, var.airflow_authentication, "")
     AIRFLOW__WEBSERVER__BASE_URL : var.use_https ? "https://${local.dns_record}" : "http://localhost:8080" # localhost is default value
+    AIRFLOW__CORE__FERNET_KEY : "arn:aws:ssm:${var.region}:${data.aws_caller_identity.this.account_id}:parameter/${var.resource_suffix}/airflow/fernet_key"
   })
 
   airflow_variables_list = formatlist("{\"name\":\"%s\",\"value\":\"%s\"}", keys(local.airflow_variables), values(local.airflow_variables))

--- a/locals.tf
+++ b/locals.tf
@@ -37,7 +37,6 @@ locals {
     AIRFLOW__WEBSERVER__RBAC : var.airflow_authentication == "" ? false : true,
     AIRFLOW__WEBSERVER__AUTH_BACKEND : lookup(local.auth_map, var.airflow_authentication, "")
     AIRFLOW__WEBSERVER__BASE_URL : var.use_https ? "https://${local.dns_record}" : "http://localhost:8080" # localhost is default value
-    AIRFLOW__CORE__FERNET_KEY : "arn:aws:ssm:${var.region}:${data.aws_caller_identity.this.account_id}:parameter/${var.resource_suffix}/airflow/fernet_key"
   })
 
   airflow_variables_list = formatlist("{\"name\":\"%s\",\"value\":\"%s\"}", keys(local.airflow_variables), values(local.airflow_variables))


### PR DESCRIPTION
The variables in airflow are being invalidated whenever the Docker container restarts. This is causing the loaders to be unable to run. I added the  `AIRFLOW__CORE__FERNET_KEY` variable anywhere it looked like it might be required.

If you see anywhere in the repo that I missed where we should include it let me know. 

I don't know much about Terraform syntax so I'm unsure if some of these work and should be reviewed.