### PR TITLE
dh-1951

### DIFF
--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -25,6 +25,9 @@ jobs:
 
       - name: Terraform Format
         run: terraform fmt -check
+      - name: Explain Format Error
+        if: ${{ failure() }}
+        run: echo "Terraform format needs to be run.  (fmt failure may not report specific issues)"
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.15.4
+          terraform_version: 1.1.8
 
       - name: Terraform Init
         run: terraform init
@@ -57,7 +57,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.15.4
+          terraform_version: 1.1.8
 
       - name: "go test"
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Maintained by dataroots](https://img.shields.io/badge/maintained%20by-dataroots-%2300b189)](https://dataroots.io)
 [![Airflow version](https://img.shields.io/badge/Apache%20Airflow-2.0.1-e27d60.svg)](https://airflow.apache.org/)
-[![Terraform 0.15](https://img.shields.io/badge/terraform-0.15-%23623CE4)](https://www.terraform.io)
+[![Terraform 1.1](https://img.shields.io/badge/terraform-1.1-%23623CE4)](https://www.terraform.io)
 [![Terraform Registry](https://img.shields.io/badge/terraform-registry-%23623CE4)](https://registry.terraform.io/modules/datarootsio/ecs-airflow/aws)
 [![Tests](https://github.com/datarootsio/terraform-aws-ecs-airflow/workflows/tests/badge.svg?branch=main)](https://github.com/datarootsio/terraform-aws-ecs-airflow/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/datarootsio/terraform-aws-ecs-airflow)](https://goreportcard.com/report/github.com/datarootsio/terraform-aws-ecs-airflow)

--- a/ecs.tf
+++ b/ecs.tf
@@ -212,11 +212,11 @@ resource "aws_ecs_task_definition" "airflow" {
 resource "aws_ecs_service" "airflow" {
   depends_on = [aws_lb.airflow, aws_db_instance.airflow]
 
-  name            = "${var.resource_prefix}-airflow-${var.resource_suffix}"
-  cluster         = aws_ecs_cluster.airflow.id
-  task_definition = aws_ecs_task_definition.airflow.id
-  desired_count   = 1
-  enable_execute_command = true
+  name                              = "${var.resource_prefix}-airflow-${var.resource_suffix}"
+  cluster                           = aws_ecs_cluster.airflow.id
+  task_definition                   = aws_ecs_task_definition.airflow.id
+  desired_count                     = 1
+  enable_execute_command            = true
   health_check_grace_period_seconds = 120
 
   network_configuration {

--- a/examples/basic-local-with-requirements/main.tf
+++ b/examples/basic-local-with-requirements/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = "~> 1.1"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/examples/basic-sequential-rbac/main.tf
+++ b/examples/basic-sequential-rbac/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = "~> 1.1"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/examples/basic-sequential/main.tf
+++ b/examples/basic-sequential/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = "~> 1.1"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/s3.tf
+++ b/s3.tf
@@ -71,7 +71,7 @@ resource "aws_s3_bucket_object" "airflow_init_entrypoint" {
     RBAC_LASTNAME   = var.rbac_admin_lastname,
     RBAC_PASSWORD   = var.rbac_admin_password,
     AIRFLOW_VERSION = var.airflow_image_tag,
-    AIRFLOW_HOME = var.airflow_container_home
+    AIRFLOW_HOME    = var.airflow_container_home
   })
 }
 

--- a/templates/startup/entrypoint_init.sh
+++ b/templates/startup/entrypoint_init.sh
@@ -6,7 +6,7 @@ airflow_major_version=$(echo ${AIRFLOW_VERSION} | awk -F. '{ print $1 }')
 # Intall python packages through req.txt and pip (if exists)
 if [[ -f "${AIRFLOW_HOME}/startup/requirements.txt" ]]; then
     echo "requirements.txt provided, installing it with pip"
-    python -m pip install -r ${AIRFLOW_HOME}/startup/requirements.txt --user
+    python -m pip install -r ${AIRFLOW_HOME}/startup/requirements.txt --user --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.4.1/constraints-3.7.txt"
 fi
 
 # airflow

--- a/test/preexisting/main.tf
+++ b/test/preexisting/main.tf
@@ -76,7 +76,7 @@ locals {
 }
 
 terraform {
-  required_version = "~> 0.15"
+  required_version = "~> 1.1"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
Using a constraints file is the recommended method for installing airflow and third party packages because it constrains packages to a working interoperable list.